### PR TITLE
Add SId and SCIds values to ScopeID of PI files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+
+clientids.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-
-clientids.csv

--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ optional arguments:
   -p          size of data packets in bytes (default 96)
   -a          packet address (default 1)
   -d DAYS     number of days ahead to encode schedule files (default 2)
+  -D          output as data groups, not packets
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 
 * [python-hybridspi](https://github.com/opendigitalradio/python-hybridspi)
 * [odr-radiodns-bridge](https://github.com/opendigitalradio/odr-radiodns-bridge)
-* [python-mot](https://github.com/opendigitalradio/python-dabmot)
+* [python-dabmot](https://github.com/opendigitalradio/python-dabmot)
 * [python-mot-epg](https://github.com/opendigitalradio/python-mot-epg)
-* [python-msc](https://github.com/opendigitalradio/python-dabmsc)
+* [python-dabmsc](https://github.com/opendigitalradio/python-dabmsc)
 * [isodate](https://pypi.python.org/pypi/isodate)
 * [bitarray](https://pypi.python.org/pypi/bitarray)
 * [crcmod](https://pypi.python.org/pypi/crcmod)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 # Usage
 
 ```
-usage: generate-epg [-h] [-o OUTPUT] [-X] [-d DAYS] f
+usage: generate-epg [-h] [-o OUTPUT] [-X] [-p bytes] [-a address] [-d DAYS] f
 
 Encodes an EPG bitstream for services in a multiplex configuration file
 
@@ -26,9 +26,10 @@ positional arguments:
 
 optional arguments:
   -h, --help  show this help message and exit
-  -o OUTPUT   output bitstream file
+  -o OUTPUT   output bitstream file (default output.dat)
   -X          turn debug on
-  -d DAYS     number of days ahead to encode schedule files
+  -p          size of data packets in bytes (default 96)
+  -a          packet address (default 1)
+  -d DAYS     number of days ahead to encode schedule files (default 2)
 ```
 
-Where the default number of `days` is 2, and the default output file is `output.dat`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 * [odr-radiodns-bridge](https://github.com/nickpiggott/odr-radiodns-bridge)
 * [python-mot](https://github.com/GlobalRadio/python-dabmot)
 * [python-mot-epg](https://github.com/GlobalRadio/python-mot-epg)
-* [python-msc](https://github.com/GlobalRadio/python-dabmsc)
+* [python-msc](https://github.com/nickpiggott/python-dabmsc)
 * [isodate](https://pypi.python.org/pypi/isodate)
 * [bitarray](https://pypi.python.org/pypi/bitarray)
 * [crcmod](https://pypi.python.org/pypi/crcmod)

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 
 # Dependencies
 
-* [python-hybridspi](https://github.com/magicbadger/python-hybridspi)
-* [odr-radiodns-bridge](https://github.com/nickpiggott/odr-radiodns-bridge)
+* [python-hybridspi](https://github.com/opendigitalradio/python-hybridspi)
+* [odr-radiodns-bridge](https://github.com/opendigitalradio/odr-radiodns-bridge)
 * [python-mot](https://github.com/GlobalRadio/python-dabmot)
 * [python-mot-epg](https://github.com/GlobalRadio/python-mot-epg)
-* [python-msc](https://github.com/nickpiggott/python-dabmsc)
+* [python-msc](https://github.com/opendigitalradio/python-dabmsc)
 * [isodate](https://pypi.python.org/pypi/isodate)
 * [bitarray](https://pypi.python.org/pypi/bitarray)
 * [crcmod](https://pypi.python.org/pypi/crcmod)

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 
 * [python-hybridspi](https://github.com/opendigitalradio/python-hybridspi)
 * [odr-radiodns-bridge](https://github.com/opendigitalradio/odr-radiodns-bridge)
-* [python-mot](https://github.com/GlobalRadio/python-dabmot)
-* [python-mot-epg](https://github.com/GlobalRadio/python-mot-epg)
+* [python-mot](https://github.com/opendigitalradio/python-dabmot)
+* [python-mot-epg](https://github.com/opendigitalradio/python-mot-epg)
 * [python-msc](https://github.com/opendigitalradio/python-dabmsc)
 * [isodate](https://pypi.python.org/pypi/isodate)
 * [bitarray](https://pypi.python.org/pypi/bitarray)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 # Usage
 
 ```
-usage: generate-epg [-h] [-o OUTPUT] [-X] [-p bytes] [-a address] [-d DAYS] f
+usage: generate-epg [-h] [-o OUTPUT] [-X] [-p bytes] [-a address] [-d DAYS] [-D] f
 
 Encodes an EPG bitstream for services in a multiplex configuration file
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ Creates a DAB EPG bitstream directly from the ODR multiplex configuration file, 
 # Usage
 
 ```
-usage: generate-epg [-h] [-o OUTPUT] [-X] [-p bytes] [-a address] [-d DAYS] [-D] f
+usage: generate-epg [-h] [-o OUTPUT] [-X] [-p bytes] [-a address] [-d DAYS] [-D] [-c filename] f
 
 Encodes an EPG bitstream for services in a multiplex configuration file
 
 positional arguments:
   f           multiplex configuration file
+              the configuration file must be in the Boost format
+              configuration files in JSON format are currently not supported
 
 optional arguments:
   -h, --help  show this help message and exit
@@ -32,5 +34,27 @@ optional arguments:
   -a          packet address (default 1)
   -d DAYS     number of days ahead to encode schedule files (default 2)
   -D          output as data groups, not packets
+  -c          filename of a CSV file containing client IDs (see below)
 ```
+
+# Client ID
+Some providers of RadioDNS SI information control access through use of a Client ID (a kind of API key).
+This Client ID must be passed as part of any request for SI or PI files; without it the request may fail
+either with a 401 (Unauthorized) error, silently or by returning a truncated (but valid) SI / PI document.
+
+Client IDs are associated with the FQDN (Full Qualified Domain Name) of the provider of the SI / PI files.
+In order to pass Client IDs to the Service Provider when making a request, you can provide the filename
+of a csv file, which contains one or more lines in the format
+{fqdn},{ClientId}
+
+for example:
+```
+radiodns.example.com,bf8f7abf-7194-4222-ab1e-3329aae254c9
+```
+
+If Authorization of a Client ID fails, odr-radioepg-bridge will move onto the next service silently. 
+The error will not be reported, and processing will not stop.
+
+To get a Client ID, you'll need to approach the radio station or their service provider directly.
+Client IDs are not issued or managed by RadioDNS or OpenDigitalRadio.
 

--- a/clientids.csv
+++ b/clientids.csv
@@ -1,0 +1,2 @@
+example.org,exampleclientid
+example.com,adifferentexampleclientid

--- a/generate-epg
+++ b/generate-epg
@@ -263,7 +263,7 @@ class Generator:
 
                            except urllib.error.HTTPError as err:
                                if err.code == 404:
-                                   logger.warning('could not find PI file at: %s', pi_url)
+                                   logger.debug('could not find PI file at: %s', pi_url)
                                else:
                                    logger.exception('error finding PI file at: %s', pi_url)
 

--- a/generate-epg
+++ b/generate-epg
@@ -115,6 +115,11 @@ class Generator:
         all_services = []
 
         logger.debug('responses: %s', responses)
+        
+        if len(responses) == 0:
+            logger.debug('No services found to encode, aborting')
+            return 
+
         for response in responses:
             fqdn = response['fqdn']
             bearers = response['bearers']

--- a/generate-epg
+++ b/generate-epg
@@ -42,6 +42,7 @@ def get_services_for_bearers(bearers, url):
     response = urllib2.urlopen(url)
     unmarshalled = xml.unmarshall(response.read())
     services = filter(lambda s : len(filter(lambda b : b in bearers, s.bearers)) > 0, unmarshalled.services)
+    logger.debug('number of services found %d', len(services))
     if len(services) == 0:
         raise Error('no services found for bearers %s from url %s' % (bearers, url))
     return services
@@ -136,12 +137,23 @@ class Generator:
 
 		    new_media = [] 
                     for media in filter(lambda m: 
-                        m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE, Multimedia.LOGO_UNRESTRICTED) or
-                        (m.content in ('image/png', 'image/jpg', 'image/jpeg') and
-                         (m.width, m.height) in ((32, 32), (112, 32), (128, 128))), 
+                        m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
+                        (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
                         service.media):
 
+			if media.type == Multimedia.LOGO_COLOUR_SQUARE :
+                             media.content = "image/png"
+                             media.width = 32
+                             media.height = 32
+                        elif media.type == Multimedia.LOGO_COLOUR_RECTANGLE :
+			     media.content = "image/png"
+                             media.width = 112
+                             media.height = 32 
+
+			logger.debug('Width %d and height %d', media.width, media.height)
+
 			# create a sensible contentname
+                        logger.debug('Media content type is %s', media.content)
 			name = "{service}_{width}_{height}.{extension}".format(
 				service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
 				width=media.width,
@@ -179,8 +191,9 @@ class Generator:
                             pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%d/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
                             try:
                                 day = now + timedelta(days=i)
-                                filename = '%s_PI_%04x' % (day.strftime("%Y%m%d"), bearer.sid)
-                                logger.debug('making request for PI file to: %s', pi_url)
+                                # filename = '%s_PI_%04x' % (day.strftime("%Y%m%d"), bearer.sid)
+				filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+                                logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
                                 f = urllib2.urlopen(pi_url)
                                 data = f.read()
                                 logger.debug('read %d bytes', len(data))
@@ -199,7 +212,7 @@ class Generator:
                                     if scope_end == None or end > scope_end: scope_end = end
 
                                 o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
-                                o.add_parameter(ScopeId(bearer.ecc, bearer.eid)) 
+                                o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
                                 o.add_parameter(ScopeStart(scope_start))
                                 o.add_parameter(ScopeEnd(scope_end))
                                 objects.append(o)
@@ -212,23 +225,30 @@ class Generator:
 
                      
         # prepare the SI file
+	# filename = 'si.xml'
+	filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         service_info = ServiceInfo()
-        logger.debug('preparing the SI file with %d services', len(all_services))
+        logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
         for service in all_services:
 
             # filter out non DAB/IP bearers
-            service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
+            # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
+            # service_info.services.append(service)  
+
+            # filter out non DAB bearers
+            service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
             service_info.services.append(service)  
 
         # add the SI file 
-        o = MotObject("si.xml", binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
+        o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
         o.add_parameter(ScopeId(ecc, eid))
         objects.append(o)
 
         logger.debug('loaded into %d MOT objects', len(objects))
 
         # encode to datagroups
-        datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+        # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+        datagroups = encode_directorymode(objects, directory_parameters=[])
         logger.debug('encoded to %d datagroups', len(datagroups))
 
         # encode to packets

--- a/generate-epg
+++ b/generate-epg
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 """
 ODR-Bridge-EPG

--- a/generate-epg
+++ b/generate-epg
@@ -118,7 +118,7 @@ class Generator:
         if self.datagroup_output:
             logger.debug('creating bitstream generator: days=%d, using datagroups', days)       
         else:
-            logger.debug('creating bitstream generator: days=%d, using packets: packet_size=%d, packet_address=%d', days, packet_size.value, packet_address)
+            logger.debug('creating bitstream generator: days=%d, using packets: packet_size=%d, packet_address=%d', days, packet_size, packet_address)
 
     def generate_epg(self, responses):
 

--- a/generate-epg
+++ b/generate-epg
@@ -23,7 +23,6 @@ import random
 import string
 import re
 import logging
-from pprint import pprint
 
 from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, xml, binary
 

--- a/generate-epg
+++ b/generate-epg
@@ -27,7 +27,7 @@ from pprint import pprint
 from PIL import Image
 from io import BytesIO
 
-from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, xml, binary, ShortDescription, LongDescription
+from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, MediumName, xml, binary, ShortDescription, LongDescription, binary
 
 from mot import MotObject, ContentType, SortedHeaderInformation
 from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd
@@ -108,12 +108,17 @@ def calculate_scope(schedule): # this should probably be in the main codebase
 
 class Generator:
 
-    def __init__(self, days, output, packet_size, packet_address, datagroup_output):
+    def __init__(self, days, output, packet_size, packet_address, datagroup_output, ecc, eid, label, shortlabel):
         self.days = days if days else 0
         self.output = output if output else 'output.dat'
         self.packet_size = packet_size
         self.packet_address = packet_address
         self.datagroup_output = datagroup_output
+        self.ecc = ecc
+        self.eid = eid
+        self.label = label
+        self.shortlabel = shortlabel
+
 
         if self.datagroup_output:
             logger.debug('creating bitstream generator: days=%d, using datagroups', days)       
@@ -141,10 +146,6 @@ class Generator:
             fqdn = response['fqdn']
             bearers = response['bearers']
             servers = response['servers']
-
-            # lets take a snapshot of ensemble ECC and EId right now, but should really take this from the mux config
-            ecc = bearers[0].ecc
-            eid = bearers[0].eid
 
             # sort servers in priority (lowest), weighting highest
             servers = sorted(servers, key=lambda x: (-x['priority'], x['weight']))
@@ -307,7 +308,9 @@ class Generator:
                 service_info.services.append(service)  
 
             # add the SI file 
-            o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)).tobytes(), EpgContentType.SERVICE_INFORMATION)
+            ensemble_label = MediumName(label)
+            ensemble_shortlabel = ShortName(shortlabel)
+            o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid, names=[ensemble_label,ensemble_shortlabel])).tobytes(), EpgContentType.SERVICE_INFORMATION)
             o.add_parameter(ScopeId(ecc, eid))
             objects.append(o)
 
@@ -340,6 +343,7 @@ class Generator:
 
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
-from odr.radiodns.resolver import resolve_epg
-generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output)
+from odr.radiodns.resolver import resolve_epg, parse_mux_ensemble
+ecc, eid, label, shortlabel = parse_mux_ensemble(args.f[0])
+generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output,ecc=ecc,eid=eid,label=label,shortlabel=shortlabel)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -249,8 +249,8 @@ class Generator:
         logger.debug('loaded into %d MOT objects', len(objects))
 
         # encode to datagroups
-        # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-        datagroups = encode_directorymode(objects, directory_parameters=[])
+        datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+        # datagroups = encode_directorymode(objects, directory_parameters=[])
         logger.debug('encoded to %d datagroups', len(datagroups))
 
         # encode to packets

--- a/generate-epg
+++ b/generate-epg
@@ -118,7 +118,7 @@ class Generator:
         if self.datagroup_output:
             logger.debug('creating bitstream generator: days=%d, using datagroups', days)       
         else:
-            logger.debug('creating bitstream generator: days=%d, using packets: packet_size=%d, packet_address=%d', days, packet_size, packet_address)
+            logger.debug('creating bitstream generator: days=%d, using packets: packet_size=%d, packet_address=%d', days, packet_size.value, packet_address)
 
     def generate_epg(self, responses):
 

--- a/generate-epg
+++ b/generate-epg
@@ -291,8 +291,8 @@ class Generator:
 
 
             # encode to datagroups
-            datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-            # datagroups = encode_directorymode(objects, directory_parameters=[])
+            # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+            datagroups = encode_directorymode(objects, directory_parameters=[])
             logger.debug('encoded to %d datagroups', len(datagroups))
         
             # open the output file

--- a/generate-epg
+++ b/generate-epg
@@ -27,7 +27,7 @@ from pprint import pprint
 from PIL import Image
 from io import BytesIO
 
-from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, xml, binary
+from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, xml, binary, ShortDescription, LongDescription
 
 from mot import MotObject, ContentType, SortedHeaderInformation
 from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd
@@ -87,7 +87,7 @@ args = parser.parse_args()
 if args.debug:
     logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('odr.bridge.epg')
-logging.getLogger('spi.binary').setLevel(logging.INFO)
+logging.getLogger('spi.binary').setLevel(logging.DEBUG)
 logging.getLogger('spi.xml').setLevel(logging.DEBUG)
 
 # read in the mux config
@@ -237,7 +237,7 @@ class Generator:
                                 logger.debug('read %d bytes', len(data))
                                 programme_info = xml.unmarshall(data)
                                 schedule_info = programme_info.schedules[0]
-                                
+
                                 # get the right scope - not entirely clear from the specification how multiple schedules should be handled
                                 # in terms of scope signalling
                                 scope_start = schedule_info.scope.start
@@ -252,6 +252,14 @@ class Generator:
                                         if scope_start == None or start < scope_start: scope_start = start
                                         if scope_end == None or end > scope_end: scope_end = end
 
+                                        # if there are no SHORT descriptions, form them from suitable length LONG descriptions
+                                        for programme in schedule.programmes:
+                                            if len(list(filter(lambda x : isinstance(x, ShortDescription), programme.descriptions))) == 0:
+                                                long_descriptions = list(filter(lambda x : isinstance(x, LongDescription) and len(x.text) <= 180, programme.descriptions))
+                                                for long_description in long_descriptions:
+                                                    programme.descriptions.append(ShortDescription(long_description.text))
+
+ 
                                         # here we force the schedule/scope/serviceScope to be the current bearer, regardless
                                         schedule_info.scope.bearers = []
                                         schedule_info.scope.bearers.append(bearer)

--- a/generate-epg
+++ b/generate-epg
@@ -223,7 +223,7 @@ class Generator:
                     bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))[0]
 
                     # now find PI files
-                    if self.days > 0 and bearer.sid != 0xcdc2 :
+                    if self.days > 0 :
                         for i in range(0, self.days):
                            day = now + timedelta(days=i)
                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))

--- a/generate-epg
+++ b/generate-epg
@@ -33,7 +33,7 @@ from mot import MotObject, ContentType, SortedHeaderInformation
 from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd
 
 from msc.datagroups import encode_directorymode
-from msc.packets import encode_packets, PacketSize
+from msc.packets import encode_packets
 
 
 def filter_by_bearer(service):
@@ -226,7 +226,7 @@ class Generator:
                     if self.days > 0:
                         for i in range(0, self.days):
                            day = now + timedelta(days=i)
-                           pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
+                           pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
                            try:
                                 day = now + timedelta(days=i)
                                 filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
@@ -320,5 +320,5 @@ class Generator:
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg
-generator = Generator(days=args.days, output=args.output, packet_size=PacketSize(args.packet_size), packet_address=args.packet_address, datagroup_output=args.datagroup_output)
+generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -57,13 +57,14 @@ def encode_image(url):
     logger.debug('read %d bytes of image data', len(data))
     return data
 
-parser = argparse.ArgumentParser(description='Encodes an EPG bitstream for services in a multiplex configuration file')
+parser = argparse.ArgumentParser(description='Encodes an SPI bitstream for services in a multiplex configuration file')
 parser.add_argument('f',  nargs=1, help='multiplex configuration file')
 parser.add_argument('-o', dest='output', help='output bitstream file')
 parser.add_argument('-X', dest='debug', action='store_true', help='turn debug on')
 parser.add_argument('-d', dest='days', type=int, default=2, help='number of days ahead to encode schedule files')
 parser.add_argument('-p', dest='packet_size', type=int, default=96, help='Packet size in bytes')
 parser.add_argument('-a', dest='packet_address', type=int, default=1, help='Packet address')
+parser.add_argument('-D', dest='datagroup_output', action='store_true', help='output Datagroups instead of Packets')
 args = parser.parse_args()
 
 if args.debug:
@@ -90,13 +91,17 @@ def calculate_scope(schedule): # this should probably be in the main codebase
 
 class Generator:
 
-    def __init__(self, days, output, packet_size, packet_address):
+    def __init__(self, days, output, packet_size, packet_address, datagroup_output):
         self.days = days if days else 0
         self.output = output if output else 'output.dat'
         self.packet_size = packet_size
         self.packet_address = packet_address
+        self.datagroup_output = datagroup_output
 
-        logger.debug('creating bitstream generator: days=%d, packet_size=%d, packet_address=%d', days, packet_size, packet_address)
+        if self.datagroup_output:
+            logger.debug('creating bitstream generator: days=%d, using datagroups', days)       
+        else:
+            logger.debug('creating bitstream generator: days=%d, using packets: packet_size=%d, packet_address=%d', days, packet_size, packet_address)
 
     def generate_epg(self, responses):
 
@@ -252,19 +257,26 @@ class Generator:
         datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
         # datagroups = encode_directorymode(objects, directory_parameters=[])
         logger.debug('encoded to %d datagroups', len(datagroups))
-
-        # encode to packets
-        packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
-        logger.debug('encoded to %d packets', len(packets))
-
+        
         # open the output file
-        w = open(self.output, 'wb')
+        if self.datagroup_output:
+            logger.debug('encoded to %d datagroups', len(datagroups))
+            w = open(self.output, 'wb')
+        
+            for datagroup in datagroups:
+                w.write(datagroup.tobytes())
 
-        for packet in packets:
-            w.write(packet.tobytes())
+        else:
+            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
+            logger.debug('encoded to %d packets', len(packets))
 
+            # open the output file
+            w = open(self.output, 'wb')
+
+            for packet in packets:
+                w.write(packet.tobytes())
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg
-generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address)
+generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -219,8 +219,7 @@ class Generator:
      
                     # get the relevant bearer for this mux
 
-                    bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))
-                    bearer = bearer[0]
+                    bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))[0]
 
                     # now find PI files
                     if self.days > 0:
@@ -251,7 +250,7 @@ class Generator:
                                         start, end = calculate_scope(schedule)
                                         if scope_start == None or start < scope_start: scope_start = start
                                         if scope_end == None or end > scope_end: scope_end = end
-  
+ 
                                         o = MotObject(filename, binary.marshall(programme_info).tobytes(), EpgContentType.PROGRAMME_INFORMATION)
                                         o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
                                         o.add_parameter(ScopeStart(scope_start))
@@ -282,7 +281,10 @@ class Generator:
                 # service_info.services.append(service)  
 
                 # filter out non DAB bearers
-                service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
+                # service.bearers = filter(lambda x: isinstance(x, DabBearer), service.bearers)
+
+                # find only the bearer for this multiplex
+                service.bearers = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)
                 service_info.services.append(service)  
 
             # add the SI file 

--- a/generate-epg
+++ b/generate-epg
@@ -33,7 +33,7 @@ from mot import MotObject, ContentType, SortedHeaderInformation
 from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd
 
 from msc.datagroups import encode_directorymode
-from msc.packets import encode_packets, PacketSize
+from msc.packets import encode_packets
 
 
 def filter_by_bearer(service):
@@ -320,5 +320,5 @@ class Generator:
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg
-generator = Generator(days=args.days, output=args.output, packet_size=PacketSize(args.packet_size), packet_address=args.packet_address, datagroup_output=args.datagroup_output)
+generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -221,97 +221,97 @@ class Generator:
                         # get the relevant bearer for this mux
                         bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
 
-                        # now find PI files
-                        if self.days > 0:
-                            for i in range(0, self.days):
-                               day = now + timedelta(days=i)
-                               pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
-                               try:
-                                    day = now + timedelta(days=i)
-                                    filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
-                                    # Uncomment this next line if you want to use legacy filenames
-                                    # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
-                                    logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
-                                    f = urllib2.urlopen(pi_url)
-                                    data = f.read()
-                                    logger.debug('read %d bytes', len(data))
-                                    programme_info = xml.unmarshall(data)
+                    # now find PI files
+                    if self.days > 0:
+                        for i in range(0, self.days):
+                           day = now + timedelta(days=i)
+                           pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
+                           try:
+                                day = now + timedelta(days=i)
+                                filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
+                                # Uncomment this next line if you want to use legacy filenames
+                                # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+                                logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
+                                f = urllib2.urlopen(pi_url)
+                                data = f.read()
+                                logger.debug('read %d bytes', len(data))
+                                programme_info = xml.unmarshall(data)
                                 
-                                    # get the right scope - not entirely clear from the specification how multiple schedules should be handled
-                                    # in terms of scope signalling
-                                    scope_start = None
-                                    scope_end = None
-                                    try:
-                                        for schedule in programme_info.schedules:
-                                            start, end = schedule.scope
-                                            if scope_start == None or start < scope_start: scope_start = start
-                                            if scope_end == None or end > scope_end: scope_start = start
-                                            start, end = calculate_scope(schedule)
-                                            if scope_start == None or start < scope_start: scope_start = start
-                                            if scope_end == None or end > scope_end: scope_end = end
+                                # get the right scope - not entirely clear from the specification how multiple schedules should be handled
+                                # in terms of scope signalling
+                                scope_start = None
+                                scope_end = None
+                                try:
+                                    for schedule in programme_info.schedules:
+                                        start, end = schedule.scope
+                                        if scope_start == None or start < scope_start: scope_start = start
+                                        if scope_end == None or end > scope_end: scope_start = start
+                                        start, end = calculate_scope(schedule)
+                                        if scope_start == None or start < scope_start: scope_start = start
+                                        if scope_end == None or end > scope_end: scope_end = end
   
-                                            o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
-                                            o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
-                                            o.add_parameter(ScopeStart(scope_start))
-                                            o.add_parameter(ScopeEnd(scope_end))
-                                            objects.append(o)
+                                        o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
+                                        o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
+                                        o.add_parameter(ScopeStart(scope_start))
+                                        o.add_parameter(ScopeEnd(scope_end))
+                                        objects.append(o)
 
-                                    except AttributeError:
-                                        logger.exception('PI file at: %s is malformed', pi_url)
+                                except AttributeError:
+                                    logger.exception('PI file at: %s is malformed', pi_url)
 
-                               except urllib2.HTTPError as err:
-                                   if err.code == 404:
-                                       logger.warning('could not find PI file at: %s', pi_url)
-                                   else:
-                                       logger.exception('error finding PI file at: %s', pi_url)
+                           except urllib2.HTTPError as err:
+                               if err.code == 404:
+                                   logger.warning('could not find PI file at: %s', pi_url)
+                               else:
+                                   logger.exception('error finding PI file at: %s', pi_url)
 
                      
-            # prepare the SI file
-            filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
-            # Uncomment this next line if you want to use legacy filenames
-            # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
-            service_info = ServiceInfo()
-            logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
-            for service in all_services:
+        # prepare the SI file
+        filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
+        # Uncomment this next line if you want to use legacy filenames
+        # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
+        service_info = ServiceInfo()
+        logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
+        for service in all_services:
     
-                # filter out non DAB/IP bearers
-                # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
-                # service_info.services.append(service)  
+            # filter out non DAB/IP bearers
+            # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
+            # service_info.services.append(service)  
 
-                # filter out non DAB bearers
-                service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
-                service_info.services.append(service)  
+            # filter out non DAB bearers
+            service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
+            service_info.services.append(service)  
 
-            # add the SI file 
-            o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
-            o.add_parameter(ScopeId(ecc, eid))
-            objects.append(o)
+        # add the SI file 
+        o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
+        o.add_parameter(ScopeId(ecc, eid))
+        objects.append(o)
 
-            logger.debug('loaded into %d MOT objects', len(objects))
+        logger.debug('loaded into %d MOT objects', len(objects))
 
 
-            # encode to datagroups
-            # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-            datagroups = encode_directorymode(objects, directory_parameters=[])
-            logger.debug('encoded to %d datagroups', len(datagroups))
+        # encode to datagroups
+        # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+        datagroups = encode_directorymode(objects, directory_parameters=[])
+        logger.debug('encoded to %d datagroups', len(datagroups))
         
+        # open the output file
+        if self.datagroup_output:
+            logger.debug('encoded to %d datagroups', len(datagroups))
+            w = open(self.output, 'wb')
+       
+            for datagroup in datagroups:
+                w.write(datagroup.tobytes())
+
+        else:
+            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
+            logger.debug('encoded to %d packets', len(packets))
+
             # open the output file
-            if self.datagroup_output:
-                logger.debug('encoded to %d datagroups', len(datagroups))
-                w = open(self.output, 'wb')
-           
-                for datagroup in datagroups:
-                    w.write(datagroup.tobytes())
-
-            else:
-                packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
-                logger.debug('encoded to %d packets', len(packets))
-
-                # open the output file
-                w = open(self.output, 'wb')
-    
-                for packet in packets:
-                    w.write(packet.tobytes())
+            w = open(self.output, 'wb')
+ 
+            for packet in packets:
+               w.write(packet.tobytes())
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg

--- a/generate-epg
+++ b/generate-epg
@@ -23,6 +23,7 @@ import random
 import string
 import re
 import logging
+from pprint import pprint
 
 from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, xml, binary
 
@@ -144,7 +145,15 @@ class Generator:
 
                 # encode service logos and prepare the SI file
                 logger.debug('encoding service logos')
-                for service in services: 
+                for service in services:
+
+		    logger.debug('==== Now working on Station %s =====', service)
+
+		    service.genres = filter(None, service.genres)                                
+
+		    if len(service.genres) == 0:
+			logger.debug('No genres are correctly defined for this station')
+
                     logger.debug('encoding service logo for: %s', service)
 
 		    new_media = [] 
@@ -205,7 +214,7 @@ class Generator:
                                 day = now + timedelta(days=i)
                                 filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
                                 # Uncomment this next line if you want to use legacy filenames
-				                # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+				# filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
                                 logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
                                 f = urllib2.urlopen(pi_url)
                                 data = f.read()

--- a/generate-epg
+++ b/generate-epg
@@ -196,7 +196,7 @@ class Generator:
                             service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
                             width=media.width,
                             height=media.height,
-                            extension=media.content[media.content.find(u"/") + 1:])
+                            extension=media.content[media.content.find("/") + 1:])
                         logger.debug('creating MOT image %s from url: %s', name, media.url)
                         
                         # create MOT Object
@@ -216,54 +216,54 @@ class Generator:
 
                         new_media.append(media)
   
-                service.media = new_media
+                        service.media = new_media
      
-                # get the relevant bearer for this mux
-                bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
+                        # get the relevant bearer for this mux
+                        bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
 
-                # now find PI files
-                if self.days > 0:
-                    for i in range(0, self.days):
-                        day = now + timedelta(days=i)
-                        pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
-                        try:
-                            day = now + timedelta(days=i)
-                            filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
-                            # Uncomment this next line if you want to use legacy filenames
-                            # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
-                            logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
-                            f = urllib2.urlopen(pi_url)
-                            data = f.read()
-                            logger.debug('read %d bytes', len(data))
-                            programme_info = xml.unmarshall(data)
+                        # now find PI files
+                        if self.days > 0:
+                            for i in range(0, self.days):
+                               day = now + timedelta(days=i)
+                               pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
+                               try:
+                                    day = now + timedelta(days=i)
+                                    filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
+                                    # Uncomment this next line if you want to use legacy filenames
+                                    # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+                                    logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
+                                    f = urllib2.urlopen(pi_url)
+                                    data = f.read()
+                                    logger.debug('read %d bytes', len(data))
+                                    programme_info = xml.unmarshall(data)
                                 
-                            # get the right scope - not entirely clear from the specification how multiple schedules should be handled
-                            # in terms of scope signalling
-                            scope_start = None
-                            scope_end = None
-                            try:
-                                for schedule in programme_info.schedules:
-                                    start, end = schedule.scope
-                                    if scope_start == None or start < scope_start: scope_start = start
-                                    if scope_end == None or end > scope_end: scope_start = start
-                                    start, end = calculate_scope(schedule)
-                                    if scope_start == None or start < scope_start: scope_start = start
-                                    if scope_end == None or end > scope_end: scope_end = end
+                                    # get the right scope - not entirely clear from the specification how multiple schedules should be handled
+                                    # in terms of scope signalling
+                                    scope_start = None
+                                    scope_end = None
+                                    try:
+                                        for schedule in programme_info.schedules:
+                                            start, end = schedule.scope
+                                            if scope_start == None or start < scope_start: scope_start = start
+                                            if scope_end == None or end > scope_end: scope_start = start
+                                            start, end = calculate_scope(schedule)
+                                            if scope_start == None or start < scope_start: scope_start = start
+                                            if scope_end == None or end > scope_end: scope_end = end
+  
+                                            o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
+                                            o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
+                                            o.add_parameter(ScopeStart(scope_start))
+                                            o.add_parameter(ScopeEnd(scope_end))
+                                            objects.append(o)
 
-                                    o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
-                                    o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
-                                    o.add_parameter(ScopeStart(scope_start))
-                                    o.add_parameter(ScopeEnd(scope_end))
-                                    objects.append(o)
+                                    except AttributeError:
+                                        logger.exception('PI file at: %s is malformed', pi_url)
 
-                            except AttributeError:
-                                logger.exception('PI file at: %s is malformed', pi_url)
-
-                        except urllib2.HTTPError as err:
-                            if err.code == 404:
-                                logger.warning('could not find PI file at: %s', pi_url)
-                            else:
-                                logger.exception('error finding PI file at: %s', pi_url)
+                               except urllib2.HTTPError as err:
+                                   if err.code == 404:
+                                       logger.warning('could not find PI file at: %s', pi_url)
+                                   else:
+                                       logger.exception('error finding PI file at: %s', pi_url)
 
                      
             # prepare the SI file
@@ -291,8 +291,8 @@ class Generator:
 
 
             # encode to datagroups
-            datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-            # datagroups = encode_directorymode(objects, directory_parameters=[])
+            # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+            datagroups = encode_directorymode(objects, directory_parameters=[])
             logger.debug('encoded to %d datagroups', len(datagroups))
         
             # open the output file

--- a/generate-epg
+++ b/generate-epg
@@ -255,6 +255,10 @@ class Generator:
                                         # here we force the schedule/scope/serviceScope to be the current bearer, regardless
                                         schedule_info.scope.bearers = []
                                         schedule_info.scope.bearers.append(bearer)
+
+                                        # and update the start/end times to reflect the schedule times
+                                        schedule_info.scope.start = scope_start
+                                        schedule_info.scope.end = scope_end
                                         programme_info.schedules[0] = schedule_info
 
                                         o = MotObject(filename, binary.marshall(programme_info).tobytes(), EpgContentType.PROGRAMME_INFORMATION)

--- a/generate-epg
+++ b/generate-epg
@@ -8,8 +8,8 @@ Feed in a multiplex configuration file and an output bitstream path.
 The mux config will be scanned for services linked to an EPG packet data channel. The service SI files will
 be resolved and demarshalled.
 
-These will then be combined to a multiplex SI file. This is then used to pull back logo files for each service in the 3 
-lowest sizes. Also 2 days PI files. All these are then encoded to an MOT directory bitstream.
+These will then be combined to a multiplex SI file. This is then used to pull back logo files for each service in the 4 
+lowest sizes. Also the specified number of days of PI files. All these are then encoded to an MOT directory bitstream.
 
 """
 
@@ -23,6 +23,10 @@ import random
 import string
 import re
 import logging
+from pprint import pprint
+
+from PIL import Image
+from io import BytesIO
 
 from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, xml, binary
 
@@ -52,11 +56,20 @@ def get_filename():
 
 def encode_image(url):
     logger.debug('encoding image from %s', url)
-    response = urllib2.urlopen(url)
+    req = urllib2.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    response = urllib2.urlopen(req)
     data = response.read()
     logger.debug('read %d bytes of image data', len(data))
     if len(data) > 16000:
         logger.debug('WARN: image size is excessive (greater than 16kBytes)')
+    image = Image.open(BytesIO(data))
+    image = image.convert("P", palette=Image.ADAPTIVE)
+    compressed = image.save("/tmp/compressed.png", optimize=True)
+    temp = open('/tmp/compressed.png','r')
+    data = temp.read()
+    temp.close()
+    logger.debug('re-sized to %d bytes of image data', len(data))
+	
     return data
 
 parser = argparse.ArgumentParser(description='Encodes an SPI bitstream for services in a multiplex configuration file')
@@ -148,7 +161,7 @@ class Generator:
 
 		    logger.debug('==== Now working on Station %s =====', service)
 
-		    service.genres = filter(None, service.genres)                                
+		    service.genres = filter(None, service.genres)
 
 		    if len(service.genres) == 0:
 			logger.debug('No genres are correctly defined for this station')

--- a/generate-epg
+++ b/generate-epg
@@ -16,7 +16,7 @@ lowest sizes. Also the specified number of days of PI files. All these are then 
 import argparse
 import os, sys
 from datetime import datetime, timedelta
-import urllib
+import urllib.request, urllib.error
 import logging
 from json import dumps, JSONEncoder
 import random

--- a/generate-epg
+++ b/generate-epg
@@ -222,7 +222,7 @@ class Generator:
                     bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))[0]
 
                     # now find PI files
-                    if self.days > 0:
+                    if self.days > 0 and bearer.sid != 0xcdc2 :
                         for i in range(0, self.days):
                            day = now + timedelta(days=i)
                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
@@ -291,6 +291,7 @@ class Generator:
         # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         if len(all_services) > 0:
             service_info = ServiceInfo()
+            service_info.originator = "OpenDigitalRadio SPI Generator"
             logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
             for service in all_services:
     

--- a/generate-epg
+++ b/generate-epg
@@ -236,11 +236,12 @@ class Generator:
                                 data = f.read().decode("utf-8")
                                 logger.debug('read %d bytes', len(data))
                                 programme_info = xml.unmarshall(data)
+                                schedule_info = programme_info.schedules[0]
                                 
                                 # get the right scope - not entirely clear from the specification how multiple schedules should be handled
                                 # in terms of scope signalling
-                                scope_start = None
-                                scope_end = None
+                                scope_start = schedule_info.scope.start
+                                scope_end = schedule_info.scope.end
                                 try:
                                     for schedule in programme_info.schedules:
                                         start = schedule.scope.start
@@ -250,7 +251,12 @@ class Generator:
                                         start, end = calculate_scope(schedule)
                                         if scope_start == None or start < scope_start: scope_start = start
                                         if scope_end == None or end > scope_end: scope_end = end
- 
+
+                                        # here we force the schedule/scope/serviceScope to be the current bearer, regardless
+                                        schedule_info.scope.bearers = []
+                                        schedule_info.scope.bearers.append(bearer)
+                                        programme_info.schedules[0] = schedule_info
+
                                         o = MotObject(filename, binary.marshall(programme_info).tobytes(), EpgContentType.PROGRAMME_INFORMATION)
                                         o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
                                         o.add_parameter(ScopeStart(scope_start))

--- a/generate-epg
+++ b/generate-epg
@@ -154,9 +154,9 @@ class Generator:
                 domain = server['target'][:-1]
                 url = 'http://%s/radiodns/spi/3.1/SI.xml' % domain 
                 logger.debug('getting SI document from %s', url)
-                # try:
-                services = get_services_for_bearers(bearers, url)
-                # except: continue # move onto the next SRV record
+                try:
+                    services = get_services_for_bearers(bearers, url)
+                except: continue # move onto the next SRV record
                 all_services.extend(services)
 
                 # encode service logos and prepare the SI file

--- a/generate-epg
+++ b/generate-epg
@@ -193,12 +193,12 @@ class Generator:
                         now = datetime.today()
                         for i in range(0, self.days):
                             day = now + timedelta(days=i)
-                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%d/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
+                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
                             try:
                                 day = now + timedelta(days=i)
-                                filename = '%s_PI_%04x' % (day.strftime("%Y%m%d"), bearer.sid)
+                                filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
                                 # Uncomment this next line if you want to use legacy filenames
-				                # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+				# filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
                                 logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
                                 f = urllib2.urlopen(pi_url)
                                 data = f.read()
@@ -231,9 +231,9 @@ class Generator:
 
                      
         # prepare the SI file
-    	filename = 'si.xml'
+    	filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
         # Uncomment this next line if you want to use legacy filenames
-	    # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
+	# filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         service_info = ServiceInfo()
         logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
         for service in all_services:

--- a/generate-epg
+++ b/generate-epg
@@ -138,7 +138,7 @@ class Generator:
 		    new_media = [] 
                     for media in filter(lambda m: 
                         m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
-                        (m.content in ('image/png', 'image/jpg', 'image/jpeg') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
+                        (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
                         service.media):
 
 			if media.type == Multimedia.LOGO_COLOUR_SQUARE :

--- a/generate-epg
+++ b/generate-epg
@@ -44,7 +44,9 @@ def filter_by_bearer(service):
 def get_services_for_bearers(bearers, url):
     logger.debug('getting services for bearers from %s : %s', url, bearers)
     response = urllib2.urlopen(url)
+    logger.debug('SI successfully opened')
     unmarshalled = xml.unmarshall(response.read())
+    logger.debug('SI successfuly unmarshalled')
     services = filter(lambda s : len(filter(lambda b : b in bearers, s.bearers)) > 0, unmarshalled.services)
     logger.debug('number of services found %d', len(services))
     if len(services) == 0:
@@ -69,7 +71,7 @@ def encode_image(url):
     data = temp.read()
     temp.close()
     logger.debug('re-sized to %d bytes of image data', len(data))
-	
+    
     return data
 
 parser = argparse.ArgumentParser(description='Encodes an SPI bitstream for services in a multiplex configuration file')
@@ -86,6 +88,7 @@ if args.debug:
     logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('odr.bridge.epg')
 logging.getLogger('spi.binary').setLevel(logging.INFO)
+logging.getLogger('spi.xml').setLevel(logging.DEBUG)
 
 # read in the mux config
 c = open(args.f[0]).read()
@@ -133,6 +136,8 @@ class Generator:
             logger.debug('No services found to encode, aborting')
             return 
 
+        now = datetime.today()
+
         for response in responses:
             fqdn = response['fqdn']
             bearers = response['bearers']
@@ -159,153 +164,154 @@ class Generator:
                 logger.debug('encoding service logos')
                 for service in services:
 
-		    logger.debug('==== Now working on Station %s =====', service)
+                    logger.debug('==== Now working on Station %s =====', service)
 
-		    service.genres = filter(None, service.genres)
+                    service.genres = filter(None, service.genres)
 
-		    if len(service.genres) == 0:
-			logger.debug('No genres are correctly defined for this station')
+                    if len(service.genres) == 0:
+                        logger.debug('No genres are correctly defined for this station')
 
                     logger.debug('encoding service logo for: %s', service)
 
-		    new_media = [] 
+                    new_media = [] 
                     for media in filter(lambda m: 
                         m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
                         (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
                         service.media):
 
-			if media.type == Multimedia.LOGO_COLOUR_SQUARE :
+                        if media.type == Multimedia.LOGO_COLOUR_SQUARE :
                              media.content = "image/png"
                              media.width = 32
                              media.height = 32
                         elif media.type == Multimedia.LOGO_COLOUR_RECTANGLE :
-			     media.content = "image/png"
+                             media.content = "image/png"
                              media.width = 112
                              media.height = 32 
 
-			logger.debug('Width %d and height %d', media.width, media.height)
-
-			# create a sensible contentname
+                        logger.debug('Width %d and height %d', media.width, media.height)
+   
+                        # create a sensible contentname
                         logger.debug('Media content type is %s', media.content)
-			name = "{service}_{width}_{height}.{extension}".format(
-				service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
-				width=media.width,
-				height=media.height,
-				extension=media.content[media.content.find("/") + 1:])
-			logger.debug('creating MOT image %s from url: %s', name, media.url)
+                        name = "{service}_{width}_{height}.{extension}".format(
+                            service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
+                            width=media.width,
+                            height=media.height,
+                            extension=media.content[media.content.find("/") + 1:])
+                        logger.debug('creating MOT image %s from url: %s', name, media.url)
                         
                         # create MOT Object
                         o = MotObject(name, encode_image(media.url), ContentType.IMAGE_PNG if media.content == 'image/png' or media.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) else ContentType.IMAGE_JFIF)
                         objects.append(o)
 
-			# set the name
-			media.url = name
+                        # set the name
+                        media.url = name
 
-			# set the type
-			if (media.width, media.height) == (32, 32):
-			    media.type = Multimedia.LOGO_COLOUR_SQUARE
-			elif (media.width, media.height) == (112, 32):
-			    media.type = Multimedia.LOGO_COLOUR_RECTANGLE
-			else:
-			    media.type = Multimedia.LOGO_UNRESTRICTED 
+                        # set the type
+                        if (media.width, media.height) == (32, 32):
+                            media.type = Multimedia.LOGO_COLOUR_SQUARE
+                        elif (media.width, media.height) == (112, 32):
+                            media.type = Multimedia.LOGO_COLOUR_RECTANGLE
+                        else:
+                            media.type = Multimedia.LOGO_UNRESTRICTED 
 
-			new_media.append(media)
-
-		    service.media = new_media
+                        new_media.append(media)
+  
+                service.media = new_media
      
-                    # get the relevant bearer for this mux
-                    bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
+                # get the relevant bearer for this mux
+                bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
 
-                    # now find PI files
-                    if self.days > 0:
-                        now = datetime.today()
-                        for i in range(0, self.days):
+                # now find PI files
+                if self.days > 0:
+                    for i in range(0, self.days):
+                        day = now + timedelta(days=i)
+                        pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
+                        try:
                             day = now + timedelta(days=i)
-                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
-                            try:
-                                day = now + timedelta(days=i)
-                                filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
-                                # Uncomment this next line if you want to use legacy filenames
-				# filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
-                                logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
-                                f = urllib2.urlopen(pi_url)
-                                data = f.read()
-                                logger.debug('read %d bytes', len(data))
-                                programme_info = xml.unmarshall(data)
+                            filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
+                            # Uncomment this next line if you want to use legacy filenames
+                            # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+                            logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
+                            f = urllib2.urlopen(pi_url)
+                            data = f.read()
+                            logger.debug('read %d bytes', len(data))
+                            programme_info = xml.unmarshall(data)
                                 
-                                # get the right scope - not entirely clear from the specification how multiple schedules should be handled
-                                # in terms of scope signalling
-                                scope_start = None
-                                scope_end = None
-                                try:
-                                    for schedule in programme_info.schedules:
-                                        start, end = schedule.scope
-                                        if scope_start == None or start < scope_start: scope_start = start
-                                        if scope_end == None or end > scope_end: scope_start = start
-                                        start, end = calculate_scope(schedule)
-                                        if scope_start == None or start < scope_start: scope_start = start
-                                        if scope_end == None or end > scope_end: scope_end = end
+                            # get the right scope - not entirely clear from the specification how multiple schedules should be handled
+                            # in terms of scope signalling
+                            scope_start = None
+                            scope_end = None
+                            try:
+                                for schedule in programme_info.schedules:
+                                    start, end = schedule.scope
+                                    if scope_start == None or start < scope_start: scope_start = start
+                                    if scope_end == None or end > scope_end: scope_start = start
+                                    start, end = calculate_scope(schedule)
+                                    if scope_start == None or start < scope_start: scope_start = start
+                                    if scope_end == None or end > scope_end: scope_end = end
 
                                     o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
                                     o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
                                     o.add_parameter(ScopeStart(scope_start))
                                     o.add_parameter(ScopeEnd(scope_end))
                                     objects.append(o)
-                                except AttributeError:
-                                    logger.exception('PI file at: %s is malformed', pi_url)
 
-                            except urllib2.HTTPError as err:
-                                if err.code == 404:
-                                    logger.warning('could not find PI file at: %s', pi_url)
-                                else:
-                                    logger.exception('error finding PI file at: %s', pi_url)
+                            except AttributeError:
+                                logger.exception('PI file at: %s is malformed', pi_url)
+
+                        except urllib2.HTTPError as err:
+                            if err.code == 404:
+                                logger.warning('could not find PI file at: %s', pi_url)
+                            else:
+                                logger.exception('error finding PI file at: %s', pi_url)
 
                      
-        # prepare the SI file
-    	filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
-        # Uncomment this next line if you want to use legacy filenames
-	# filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
-        service_info = ServiceInfo()
-        logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
-        for service in all_services:
+            # prepare the SI file
+            filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
+            # Uncomment this next line if you want to use legacy filenames
+            # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
+            service_info = ServiceInfo()
+            logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
+            for service in all_services:
+    
+                # filter out non DAB/IP bearers
+                # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
+                # service_info.services.append(service)  
 
-            # filter out non DAB/IP bearers
-            # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
-            # service_info.services.append(service)  
+                # filter out non DAB bearers
+                service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
+                service_info.services.append(service)  
 
-            # filter out non DAB bearers
-            service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
-            service_info.services.append(service)  
+            # add the SI file 
+            o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
+            o.add_parameter(ScopeId(ecc, eid))
+            objects.append(o)
 
-        # add the SI file 
-        o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
-        o.add_parameter(ScopeId(ecc, eid))
-        objects.append(o)
+            logger.debug('loaded into %d MOT objects', len(objects))
 
-        logger.debug('loaded into %d MOT objects', len(objects))
 
-        # encode to datagroups
-        datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-        # datagroups = encode_directorymode(objects, directory_parameters=[])
-        logger.debug('encoded to %d datagroups', len(datagroups))
-        
-        # open the output file
-        if self.datagroup_output:
+            # encode to datagroups
+            datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+            # datagroups = encode_directorymode(objects, directory_parameters=[])
             logger.debug('encoded to %d datagroups', len(datagroups))
-            w = open(self.output, 'wb')
         
-            for datagroup in datagroups:
-                w.write(datagroup.tobytes())
-
-        else:
-            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
-            logger.debug('encoded to %d packets', len(packets))
-
             # open the output file
-            w = open(self.output, 'wb')
+            if self.datagroup_output:
+                logger.debug('encoded to %d datagroups', len(datagroups))
+                w = open(self.output, 'wb')
+           
+                for datagroup in datagroups:
+                    w.write(datagroup.tobytes())
 
-            for packet in packets:
-                w.write(packet.tobytes())
+            else:
+                packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
+                logger.debug('encoded to %d packets', len(packets))
+
+                # open the output file
+                w = open(self.output, 'wb')
+    
+                for packet in packets:
+                    w.write(packet.tobytes())
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg

--- a/generate-epg
+++ b/generate-epg
@@ -136,10 +136,6 @@ class Generator:
 
         logger.debug('responses: %s', responses)
         
-#        if len(responses) == 0:
-#           logger.debug('No services found to encode, aborting')
-#            return 
-
         now = datetime.today()
 
         for response in responses:

--- a/generate-epg
+++ b/generate-epg
@@ -136,9 +136,9 @@ class Generator:
 
         logger.debug('responses: %s', responses)
         
-        if len(responses) == 0:
-            logger.debug('No services found to encode, aborting')
-            return 
+#        if len(responses) == 0:
+#           logger.debug('No services found to encode, aborting')
+#            return 
 
         now = datetime.today()
 
@@ -223,7 +223,7 @@ class Generator:
                     bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))[0]
 
                     # now find PI files
-                    if self.days > 0 and bearer.sid != 0xcdc2 :
+                    if self.days > 0 :
                         for i in range(0, self.days):
                            day = now + timedelta(days=i)
                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
@@ -290,57 +290,53 @@ class Generator:
         filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
         # Uncomment this next line if you want to use legacy filenames
         # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
-        if len(all_services) > 0:
-            service_info = ServiceInfo()
-            service_info.originator = "OpenDigitalRadio SPI Generator"
-            logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
-            for service in all_services:
+        service_info = ServiceInfo()
+        service_info.originator = "OpenDigitalRadio SPI Generator"
+        logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
+        for service in all_services:
     
-                # filter out non DAB/IP bearers
-                # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
-                # service_info.services.append(service)  
+            # filter out non DAB/IP bearers
+            # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
+            # service_info.services.append(service)  
 
-                # filter out non DAB bearers
-                # service.bearers = filter(lambda x: isinstance(x, DabBearer), service.bearers)
+            # filter out non DAB bearers
+            # service.bearers = filter(lambda x: isinstance(x, DabBearer), service.bearers)
 
-                # find only the bearer for this multiplex
-                service.bearers = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)
-                service_info.services.append(service)  
+            # find only the bearer for this multiplex
+            service.bearers = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)
+            service_info.services.append(service)  
 
-            # add the SI file 
-            ensemble_label = MediumName(label)
-            ensemble_shortlabel = ShortName(shortlabel)
-            o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid, names=[ensemble_label,ensemble_shortlabel])).tobytes(), EpgContentType.SERVICE_INFORMATION)
-            o.add_parameter(ScopeId(ecc, eid))
-            objects.append(o)
+        # add the SI file 
+        ensemble_label = MediumName(label)
+        ensemble_shortlabel = ShortName(shortlabel)
+        o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid, names=[ensemble_label,ensemble_shortlabel])).tobytes(), EpgContentType.SERVICE_INFORMATION)
+        o.add_parameter(ScopeId(ecc, eid))
+        objects.append(o)
 
-            logger.debug('loaded into %d MOT objects', len(objects))
+        logger.debug('loaded into %d MOT objects', len(objects))
 
 
-            # encode to datagroups
-            # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-            datagroups = encode_directorymode(objects, directory_parameters=[])
-            logger.debug('encoded to %d datagroups', len(datagroups))
+        # encode to datagroups
+        # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+        datagroups = encode_directorymode(objects, directory_parameters=[])
+        logger.debug('encoded to %d datagroups', len(datagroups))
         
-            # open the output file
-            if self.datagroup_output:
-                w = open(self.output, 'wb')
+        # open the output file
+        if self.datagroup_output:
+            w = open(self.output, 'wb')
        
-                for datagroup in datagroups:
-                    w.write(datagroup.tobytes())
+            for datagroup in datagroups:
+                w.write(datagroup.tobytes())
 
-            else:
-                packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
-                logger.debug('encoded to %d packets', len(packets))
-
-                # open the output file
-                w = open(self.output, 'wb')
- 
-                for packet in packets:
-                   w.write(packet.tobytes())
         else:
-            logger.debug('No service content was discovered, no file generated')
+            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
+            logger.debug('encoded to %d packets', len(packets))
 
+            # open the output file
+            w = open(self.output, 'wb')
+ 
+            for packet in packets:
+               w.write(packet.tobytes())
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg, parse_mux_ensemble

--- a/generate-epg
+++ b/generate-epg
@@ -33,7 +33,7 @@ from mot import MotObject, ContentType, SortedHeaderInformation
 from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd
 
 from msc.datagroups import encode_directorymode
-from msc.packets import encode_packets
+from msc.packets import encode_packets, PacketSize
 
 
 def filter_by_bearer(service):
@@ -320,5 +320,5 @@ class Generator:
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg
-generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output)
+generator = Generator(days=args.days, output=args.output, packet_size=PacketSize(args.packet_size), packet_address=args.packet_address, datagroup_output=args.datagroup_output)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -55,6 +55,8 @@ def encode_image(url):
     response = urllib2.urlopen(url)
     data = response.read()
     logger.debug('read %d bytes of image data', len(data))
+    if len(data) > 16000:
+        logger.debug('WARN: image size is excessive (greater than 16kBytes)')
     return data
 
 parser = argparse.ArgumentParser(description='Encodes an SPI bitstream for services in a multiplex configuration file')

--- a/generate-epg
+++ b/generate-epg
@@ -62,15 +62,15 @@ def encode_image(url):
     response = urllib2.urlopen(req)
     data = response.read()
     logger.debug('read %d bytes of image data', len(data))
-    if len(data) > 16000:
-        logger.debug('WARN: image size is excessive (greater than 16kBytes)')
-    image = Image.open(BytesIO(data))
-    image = image.convert("P", palette=Image.ADAPTIVE)
-    compressed = image.save("/tmp/compressed.png", optimize=True)
-    temp = open('/tmp/compressed.png','r')
-    data = temp.read()
-    temp.close()
-    logger.debug('re-sized to %d bytes of image data', len(data))
+    if len(data) > 5000:
+        logger.debug('WARN: image size is excessive (greater than 5kBytes)')
+        image = Image.open(BytesIO(data))
+        image = image.convert("P", palette=Image.ADAPTIVE)
+        compressed = image.save("/tmp/compressed.png", optimize=True)
+        temp = open('/tmp/compressed.png','r')
+        data = temp.read()
+        temp.close()
+        logger.debug('re-sized to %d bytes of image data', len(data))
     
     return data
 
@@ -174,33 +174,33 @@ class Generator:
                     logger.debug('encoding service logo for: %s', service)
 
                     new_media = [] 
+		    logo_count = 1;
                     for media in filter(lambda m: 
                         m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
                         (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
                         service.media):
 
                         if media.type == Multimedia.LOGO_COLOUR_SQUARE :
-                             media.content = "image/png"
                              media.width = 32
                              media.height = 32
                         elif media.type == Multimedia.LOGO_COLOUR_RECTANGLE :
-                             media.content = "image/png"
                              media.width = 112
-                             media.height = 32 
+                             media.height = 32
 
                         logger.debug('Width %d and height %d', media.width, media.height)
    
                         # create a sensible contentname
                         logger.debug('Media content type is %s', media.content)
-                        name = "{service}_{width}_{height}.{extension}".format(
+                        name = "{service}_{count}_{width}_{height}.png".format(
                             service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
+			    count=logo_count,
                             width=media.width,
-                            height=media.height,
-                            extension=media.content[media.content.find("/") + 1:])
+                            height=media.height)
+ 			logo_count+=1
                         logger.debug('creating MOT image %s from url: %s', name, media.url)
                         
                         # create MOT Object
-                        o = MotObject(name, encode_image(media.url), ContentType.IMAGE_PNG if media.content == 'image/png' or media.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) else ContentType.IMAGE_JFIF)
+                        o = MotObject(name, encode_image(media.url), ContentType.IMAGE_PNG)
                         objects.append(o)
 
                         # set the name
@@ -216,10 +216,10 @@ class Generator:
 
                         new_media.append(media)
   
-                        service.media = new_media
+                    service.media = new_media
      
-                        # get the relevant bearer for this mux
-                        bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
+                    # get the relevant bearer for this mux
+                    bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
 
                     # now find PI files
                     if self.days > 0:
@@ -271,7 +271,7 @@ class Generator:
         # Uncomment this next line if you want to use legacy filenames
         # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         service_info = ServiceInfo()
-        logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
+        logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
         for service in all_services:
     
             # filter out non DAB/IP bearers

--- a/generate-epg
+++ b/generate-epg
@@ -138,7 +138,7 @@ class Generator:
 		    new_media = [] 
                     for media in filter(lambda m: 
                         m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
-                        (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
+                        (m.content in ('image/png', 'image/jpg', 'image/jpeg') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
                         service.media):
 
 			if media.type == Multimedia.LOGO_COLOUR_SQUARE :
@@ -191,8 +191,9 @@ class Generator:
                             pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%d/%s' % (domain, ((bearer.eid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
                             try:
                                 day = now + timedelta(days=i)
-                                # filename = '%s_PI_%04x' % (day.strftime("%Y%m%d"), bearer.sid)
-				filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+                                filename = '%s_PI_%04x' % (day.strftime("%Y%m%d"), bearer.sid)
+                                # Uncomment this next line if you want to use legacy filenames
+				                # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
                                 logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
                                 f = urllib2.urlopen(pi_url)
                                 data = f.read()
@@ -225,8 +226,9 @@ class Generator:
 
                      
         # prepare the SI file
-	# filename = 'si.xml'
-	filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
+    	filename = 'si.xml'
+        # Uncomment this next line if you want to use legacy filenames
+	    # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         service_info = ServiceInfo()
         logger.debug('preparing the SI file with %d services to write out as %s', len(all_services), filename)
         for service in all_services:
@@ -266,6 +268,3 @@ class Generator:
 from odr.radiodns.resolver import resolve_epg
 generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address)
 resolved = resolve_epg(args.f[0], generator.generate_epg)
-
-
-

--- a/generate-epg
+++ b/generate-epg
@@ -27,7 +27,7 @@ from pprint import pprint
 from PIL import Image
 from io import BytesIO
 
-from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, MediumName, xml, binary, ShortDescription, LongDescription, binary
+from spi import DabBearer, IpBearer, Time, ServiceInfo, Multimedia, ShortName, MediumName, xml, binary, ShortDescription, LongDescription
 
 from mot import MotObject, ContentType, SortedHeaderInformation
 from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd

--- a/generate-epg
+++ b/generate-epg
@@ -196,7 +196,7 @@ class Generator:
                             service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
                             width=media.width,
                             height=media.height,
-                            extension=media.content[media.content.find("/") + 1:])
+                            extension=media.content[media.content.find(u"/") + 1:])
                         logger.debug('creating MOT image %s from url: %s', name, media.url)
                         
                         # create MOT Object

--- a/generate-epg
+++ b/generate-epg
@@ -205,30 +205,33 @@ class Generator:
                                 day = now + timedelta(days=i)
                                 filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
                                 # Uncomment this next line if you want to use legacy filenames
-				# filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+				                # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
                                 logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
                                 f = urllib2.urlopen(pi_url)
                                 data = f.read()
                                 logger.debug('read %d bytes', len(data))
                                 programme_info = xml.unmarshall(data)
-
+                                
                                 # get the right scope - not entirely clear from the specification how multiple schedules should be handled
                                 # in terms of scope signalling
                                 scope_start = None
                                 scope_end = None
-                                for schedule in programme_info.schedules:
-                                    start, end = schedule.scope
-                                    if scope_start == None or start < scope_start: scope_start = start
-                                    if scope_end == None or end > scope_end: scope_start = start
-                                    start, end = calculate_scope(schedule)
-                                    if scope_start == None or start < scope_start: scope_start = start
-                                    if scope_end == None or end > scope_end: scope_end = end
+                                try:
+                                    for schedule in programme_info.schedules:
+                                        start, end = schedule.scope
+                                        if scope_start == None or start < scope_start: scope_start = start
+                                        if scope_end == None or end > scope_end: scope_start = start
+                                        start, end = calculate_scope(schedule)
+                                        if scope_start == None or start < scope_start: scope_start = start
+                                        if scope_end == None or end > scope_end: scope_end = end
 
-                                o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
-                                o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
-                                o.add_parameter(ScopeStart(scope_start))
-                                o.add_parameter(ScopeEnd(scope_end))
-                                objects.append(o)
+                                    o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
+                                    o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
+                                    o.add_parameter(ScopeStart(scope_start))
+                                    o.add_parameter(ScopeEnd(scope_end))
+                                    objects.append(o)
+                                except AttributeError:
+                                    logger.exception('PI file at: %s is malformed', pi_url)
 
                             except urllib2.HTTPError as err:
                                 if err.code == 404:

--- a/generate-epg
+++ b/generate-epg
@@ -16,13 +16,12 @@ lowest sizes. Also the specified number of days of PI files. All these are then 
 import argparse
 import os, sys
 from datetime import datetime, timedelta
-import urllib2
+import urllib
 import logging
 from json import dumps, JSONEncoder
 import random
 import string
 import re
-import logging
 from pprint import pprint
 
 from PIL import Image
@@ -43,14 +42,15 @@ def filter_by_bearer(service):
 
 def get_services_for_bearers(bearers, url):
     logger.debug('getting services for bearers from %s : %s', url, bearers)
-    response = urllib2.urlopen(url)
+    response = urllib.request.urlopen(url)
     logger.debug('SI successfully opened')
-    unmarshalled = xml.unmarshall(response.read())
+    unmarshalled = xml.unmarshall(response.read().decode('utf-8'))
     logger.debug('SI successfuly unmarshalled')
-    services = filter(lambda s : len(filter(lambda b : b in bearers, s.bearers)) > 0, unmarshalled.services)
+
+    services = list(filter(lambda s : len(list(filter(lambda b : b in bearers, s.bearers))) > 0, unmarshalled.services))
     logger.debug('number of services found %d', len(services))
     if len(services) == 0:
-        raise Error('no services found for bearers %s from url %s' % (bearers, url))
+        logger.debug('no services found for bearers %s from url %s',bearers, url)
     return services
 
 def get_filename():
@@ -58,18 +58,18 @@ def get_filename():
 
 def encode_image(url):
     logger.debug('encoding image from %s', url)
-    req = urllib2.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
-    response = urllib2.urlopen(req)
-    data = response.read()
+    req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
+    data = urllib.request.urlopen(req).read()
     logger.debug('read %d bytes of image data', len(data))
     if len(data) > 5000:
         logger.debug('WARN: image size is excessive (greater than 5kBytes)')
         image = Image.open(BytesIO(data))
         image = image.convert("P", palette=Image.ADAPTIVE)
         compressed = image.save("/tmp/compressed.png", optimize=True)
-        temp = open('/tmp/compressed.png','r')
+        temp = open('/tmp/compressed.png','rb')
         data = temp.read()
         temp.close()
+        os.remove('/tmp/compressed.png')
         logger.debug('re-sized to %d bytes of image data', len(data))
     
     return data
@@ -94,7 +94,8 @@ logging.getLogger('spi.xml').setLevel(logging.DEBUG)
 c = open(args.f[0]).read()
 
 def calculate_scope(schedule): # this should probably be in the main codebase
-    start, end = schedule.scope
+    start = schedule.scope.start
+    end = schedule.scope.end
     if start is not None and end is not None: return (start, end)
     if start is None:
         for programme in schedule.programmes:
@@ -104,8 +105,6 @@ def calculate_scope(schedule): # this should probably be in the main codebase
                     if start is None or time.actual_time < start: start = time.actual_time
                     if end is None or (time.actual_time + time.actual_duration) > end: end = (time.actual_time + time.actual_duration)
     return (start, end)
-
-
 
 class Generator:
 
@@ -155,9 +154,9 @@ class Generator:
                 domain = server['target'][:-1]
                 url = 'http://%s/radiodns/spi/3.1/SI.xml' % domain 
                 logger.debug('getting SI document from %s', url)
-                try:
-                    services = get_services_for_bearers(bearers, url)
-                except: continue # move onto the next SRV record
+                # try:
+                services = get_services_for_bearers(bearers, url)
+                # except: continue # move onto the next SRV record
                 all_services.extend(services)
 
                 # encode service logos and prepare the SI file
@@ -166,7 +165,7 @@ class Generator:
 
                     logger.debug('==== Now working on Station %s =====', service)
 
-                    service.genres = filter(None, service.genres)
+                    service.genres = list(filter(None, service.genres))
 
                     if len(service.genres) == 0:
                         logger.debug('No genres are correctly defined for this station')
@@ -174,7 +173,7 @@ class Generator:
                     logger.debug('encoding service logo for: %s', service)
 
                     new_media = [] 
-		    logo_count = 1;
+                    logo_count = 1
                     for media in filter(lambda m: 
                         m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
                         (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
@@ -196,7 +195,7 @@ class Generator:
 			    count=logo_count,
                             width=media.width,
                             height=media.height)
- 			logo_count+=1
+                        logo_count+=1
                         logger.debug('creating MOT image %s from url: %s', name, media.url)
                         
                         # create MOT Object
@@ -219,7 +218,9 @@ class Generator:
                     service.media = new_media
      
                     # get the relevant bearer for this mux
-                    bearer = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)[0]
+
+                    bearer = list(filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers))
+                    bearer = bearer[0]
 
                     # now find PI files
                     if self.days > 0:
@@ -232,8 +233,8 @@ class Generator:
                                 # Uncomment this next line if you want to use legacy filenames
                                 # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
                                 logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
-                                f = urllib2.urlopen(pi_url)
-                                data = f.read()
+                                f = urllib.request.urlopen(pi_url)
+                                data = f.read().decode("utf-8")
                                 logger.debug('read %d bytes', len(data))
                                 programme_info = xml.unmarshall(data)
                                 
@@ -243,14 +244,15 @@ class Generator:
                                 scope_end = None
                                 try:
                                     for schedule in programme_info.schedules:
-                                        start, end = schedule.scope
+                                        start = schedule.scope.start
+                                        end = schedule.scope.end
                                         if scope_start == None or start < scope_start: scope_start = start
                                         if scope_end == None or end > scope_end: scope_start = start
                                         start, end = calculate_scope(schedule)
                                         if scope_start == None or start < scope_start: scope_start = start
                                         if scope_end == None or end > scope_end: scope_end = end
   
-                                        o = MotObject(filename, binary.marshall(programme_info), EpgContentType.PROGRAMME_INFORMATION)
+                                        o = MotObject(filename, binary.marshall(programme_info).tobytes(), EpgContentType.PROGRAMME_INFORMATION)
                                         o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
                                         o.add_parameter(ScopeStart(scope_start))
                                         o.add_parameter(ScopeEnd(scope_end))
@@ -259,7 +261,7 @@ class Generator:
                                 except AttributeError:
                                     logger.exception('PI file at: %s is malformed', pi_url)
 
-                           except urllib2.HTTPError as err:
+                           except urllib.error.HTTPError as err:
                                if err.code == 404:
                                    logger.warning('could not find PI file at: %s', pi_url)
                                else:
@@ -270,48 +272,51 @@ class Generator:
         filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
         # Uncomment this next line if you want to use legacy filenames
         # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
-        service_info = ServiceInfo()
-        logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
-        for service in all_services:
+        if len(all_services) > 0:
+            service_info = ServiceInfo()
+            logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
+            for service in all_services:
     
-            # filter out non DAB/IP bearers
-            # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
-            # service_info.services.append(service)  
+                # filter out non DAB/IP bearers
+                # service.bearers = filter(lambda x: isinstance(x, (DabBearer, IpBearer)), service.bearers)
+                # service_info.services.append(service)  
 
-            # filter out non DAB bearers
-            service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
-            service_info.services.append(service)  
+                # filter out non DAB bearers
+                service.bearers = filter(lambda x: isinstance(x, (DabBearer)), service.bearers)
+                service_info.services.append(service)  
 
-        # add the SI file 
-        o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)), EpgContentType.SERVICE_INFORMATION)
-        o.add_parameter(ScopeId(ecc, eid))
-        objects.append(o)
+            # add the SI file 
+            o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid)).tobytes(), EpgContentType.SERVICE_INFORMATION)
+            o.add_parameter(ScopeId(ecc, eid))
+            objects.append(o)
 
-        logger.debug('loaded into %d MOT objects', len(objects))
+            logger.debug('loaded into %d MOT objects', len(objects))
 
 
-        # encode to datagroups
-        # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
-        datagroups = encode_directorymode(objects, directory_parameters=[])
-        logger.debug('encoded to %d datagroups', len(datagroups))
-        
-        # open the output file
-        if self.datagroup_output:
+            # encode to datagroups
+            # datagroups = encode_directorymode(objects, directory_parameters=[SortedHeaderInformation()])
+            datagroups = encode_directorymode(objects, directory_parameters=[])
             logger.debug('encoded to %d datagroups', len(datagroups))
-            w = open(self.output, 'wb')
-       
-            for datagroup in datagroups:
-                w.write(datagroup.tobytes())
-
-        else:
-            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
-            logger.debug('encoded to %d packets', len(packets))
-
+        
             # open the output file
-            w = open(self.output, 'wb')
+            if self.datagroup_output:
+                w = open(self.output, 'wb')
+       
+                for datagroup in datagroups:
+                    w.write(datagroup.tobytes())
+
+            else:
+                packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
+                logger.debug('encoded to %d packets', len(packets))
+
+                # open the output file
+                w = open(self.output, 'wb')
  
-            for packet in packets:
-               w.write(packet.tobytes())
+                for packet in packets:
+                   w.write(packet.tobytes())
+        else:
+            logger.debug('No service content was discovered, no file generated')
+
 
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg

--- a/generate-epg
+++ b/generate-epg
@@ -75,9 +75,21 @@ def encode_image(url):
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     data = urllib.request.urlopen(req).read()
     logger.debug('read %d bytes of image data', len(data))
+    image = Image.open(BytesIO(data))
+    if (image.width != width) or (image.height != height):
+        logger.debug('WARN: image dimensions are incorrect (width:%d, height:%d)', image.width, image.height)
+        image = image.resize(size=[width, height], resample=Image.BICUBIC)
+        tf = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+        tempname = tf.name
+        tf.close()
+        compressed = image.save(tempname)
+        temp = open(tempname,'rb')
+        data = temp.read()
+        temp.close()
+        os.remove(tempname)
+        logger.debug('re-sized to width %d and height %d', width, height)
     if len(data) > 5000:
         logger.debug('WARN: image size is excessive (greater than 5kBytes)')
-        image = Image.open(BytesIO(data))
         image = image.convert("P", palette=Image.ADAPTIVE)
         tf = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
         tempname = tf.name
@@ -88,7 +100,7 @@ def encode_image(url):
         temp.close()
         os.remove(tempname)
         logger.debug('re-sized to %d bytes of image data', len(data))
-    
+
     return data
 
 parser = argparse.ArgumentParser(description='Encodes an SPI bitstream for services in a multiplex configuration file')

--- a/generate-epg
+++ b/generate-epg
@@ -340,10 +340,11 @@ class Generator:
             # service_info.services.append(service)  
 
             # filter out non DAB bearers
-            # service.bearers = filter(lambda x: isinstance(x, DabBearer), service.bearers)
+            service.bearers = filter(lambda x: isinstance(x, DabBearer), service.bearers)
 
             # find only the bearer for this multiplex
-            service.bearers = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)
+            # service.bearers = filter(lambda x: isinstance(x, DabBearer) and x.ecc == ecc and x.eid == eid, service.bearers)
+
             service_info.services.append(service)  
 
         # add the SI file 

--- a/generate-epg
+++ b/generate-epg
@@ -43,10 +43,10 @@ def filter_by_bearer(service):
 
 def get_services_for_bearers(bearers, url, clientkey):
     logger.debug('getting services for bearers from %s : %s', url, bearers)
-    req = urlib.request(url)
-    if clientkey is not None:
+    req = urllib.request.Request(url)
+    if clientkey:
         req.add_header("Authorization", "ClientIdentifier " + clientkey)
-    response = req.urlopen(url)
+    response = urllib.request.urlopen(req)
     logger.debug('SI successfully opened')
     unmarshalled = xml.unmarshall(response.read().decode('utf-8'))
     logger.debug('SI successfuly unmarshalled')
@@ -154,11 +154,12 @@ class Generator:
             fqdn = response['fqdn']
             bearers = response['bearers']
             servers = response['servers']
+            app = response['app']
             clientkey = ""
             
             # is there a client id for this fqdn
             for clientid in clientids:
-                if clientid[0] == fqdn:
+                if (clientid[0] + ".") == fqdn:
                     clientkey = clientid[1]
 
             # sort servers in priority (lowest), weighting highest
@@ -166,8 +167,12 @@ class Generator:
 
             # acquire an SI file, starting with the lower priority
             for server in servers:
+                print(server)
                 domain = server['target'][:-1]
-                url = 'http://%s/radiodns/spi/3.1/SI.xml' % domain 
+                if app == "radiospi":
+                    url = 'https://%s/radiodns/spi/3.1/SI.xml' % domain 
+                else:
+                    url = 'http://%s/radiodns/spi/3.1/SI.xml' % domain 
                 logger.debug('getting SI document from %s', url)
                 try:
                     services = get_services_for_bearers(bearers, url, clientkey)

--- a/generate-epg
+++ b/generate-epg
@@ -311,7 +311,8 @@ class Generator:
                                    logger.debug('could not find PI file at: %s', pi_url)
                                else:
                                    logger.exception('error finding PI file at: %s', pi_url)
-
+                           except:
+                                   logger.exception('PI file at: %s is malformed', pi_url)
                      
         # prepare the SI file
         filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)

--- a/generate-epg
+++ b/generate-epg
@@ -356,7 +356,7 @@ class Generator:
                 w.write(datagroup.tobytes())
 
         else:
-            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size)
+            packets = encode_packets(datagroups, address=self.packet_address, size=self.packet_size, padding=True)
             logger.debug('encoded to %d packets', len(packets))
 
             # open the output file

--- a/generate-epg
+++ b/generate-epg
@@ -342,7 +342,7 @@ class Generator:
         ensemble_shortlabel = ShortName(shortlabel)
         o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid, names=[ensemble_label,ensemble_shortlabel])).tobytes(), EpgContentType.SERVICE_INFORMATION)
         o.add_parameter(ScopeId(ecc, eid))
-        objects.append(o)
+        objects.insert(0, o)
 
         logger.debug('loaded into %d MOT objects', len(objects))
 

--- a/generate-epg
+++ b/generate-epg
@@ -37,6 +37,18 @@ from mot.epg import EpgContentType, ScopeId, ScopeStart, ScopeEnd
 from msc.datagroups import encode_directorymode
 from msc.packets import encode_packets
 
+def parse_mux_pkt_size_addr(filename, args_packet_size, args_packet_address):
+    from odr.radiodns.resolver import parse_mux_config
+    mux_packet_size = args_packet_size
+    mux_packet_address = args_packet_address
+    services = (parse_mux_config(filename))
+    for service in services:
+      if service["hasEPG"]:
+        mux_packet_size = service["EPGpacketSize"]
+        mux_packet_address = service["EPGpacketAddress"]
+        if mux_packet_size > 96:
+          mux_packet_size = mux_packet_size // 2
+    return mux_packet_size, mux_packet_address
 
 def filter_by_bearer(service):
     bearers = [x for x in service.bearers if isinstance(x, (DabBearer))] # can include IP bearers if you like
@@ -379,8 +391,10 @@ class Generator:
             for packet in packets:
                w.write(packet.tobytes())
 
+# get packet_size and packet_address from the mux config
+mux_packet_size, mux_packet_address = parse_mux_pkt_size_addr(args.f[0], args.packet_size, args.packet_address)
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg, parse_mux_ensemble
 ecc, eid, label, shortlabel = parse_mux_ensemble(args.f[0])
-generator = Generator(days=args.days, output=args.output, packet_size=args.packet_size, packet_address=args.packet_address, datagroup_output=args.datagroup_output,ecc=ecc,eid=eid,label=label,shortlabel=shortlabel)
+generator = Generator(days=args.days, output=args.output, packet_size=mux_packet_size, packet_address=mux_packet_address, datagroup_output=args.datagroup_output,ecc=ecc,eid=eid,label=label,shortlabel=shortlabel)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -46,9 +46,10 @@ def parse_mux_pkt_size_addr(filename, args_packet_size, args_packet_address):
       if service["hasEPG"]:
         mux_packet_size = service["EPGpacketSize"]
         mux_packet_address = service["EPGpacketAddress"]
-        if mux_packet_size > 96:
-          mux_packet_size = mux_packet_size // 2
-    return mux_packet_size, mux_packet_address
+    mux_packet_bitrate = mux_packet_size // 3
+    if mux_packet_size > 96:
+      mux_packet_size = mux_packet_size // 2
+    return mux_packet_size, mux_packet_address, mux_packet_bitrate
 
 def filter_by_bearer(service):
     bearers = [x for x in service.bearers if isinstance(x, (DabBearer))] # can include IP bearers if you like
@@ -166,11 +167,12 @@ def calculate_scope(schedule): # this should probably be in the main codebase
 
 class Generator:
 
-    def __init__(self, days, output, packet_size, packet_address, datagroup_output, ecc, eid, label, shortlabel):
+    def __init__(self, days, output, packet_size, packet_address, packet_bitrate, datagroup_output, ecc, eid, label, shortlabel):
         self.days = days if days else 0
         self.output = output if output else 'output.dat'
         self.packet_size = packet_size
         self.packet_address = packet_address
+        self.packet_bitrate = packet_bitrate
         self.datagroup_output = datagroup_output
         self.ecc = ecc
         self.eid = eid
@@ -394,13 +396,27 @@ class Generator:
             # open the output file
             w = open(self.output, 'wb')
  
+            firstpkt = True
+            cyclesize = 0
+            packetssize = 0
             for packet in packets:
-               w.write(packet.tobytes())
+               pktbytes = packet.tobytes()
+               w.write(pktbytes)
+               if firstpkt:
+                  firstbytes = pktbytes[0:4]
+                  firstpkt = False
+               elif not firstpkt and (cyclesize == 0) and ((firstbytes[0] & 0xCF) == (pktbytes[0] & 0xCF)) and (firstbytes[1] == pktbytes[1]) and (firstbytes[2] == pktbytes[2]) and (firstbytes[3] == pktbytes[3]):
+                 cyclesize = packetssize
+               packetssize += len(pktbytes)
+            if cyclesize == 0:
+               cyclesize = packetssize
+
+            logger.debug('expected SPI cycle time: %d seconds', round(cyclesize * 8 / self.packet_bitrate / 1000))
 
 # get packet_size and packet_address from the mux config
-mux_packet_size, mux_packet_address = parse_mux_pkt_size_addr(args.f[0], args.packet_size, args.packet_address)
+mux_packet_size, mux_packet_address, mux_packet_bitrate = parse_mux_pkt_size_addr(args.f[0], args.packet_size, args.packet_address)
 # get the services and applications that the mux config suggests and construct a new virtual SI file
 from odr.radiodns.resolver import resolve_epg, parse_mux_ensemble
 ecc, eid, label, shortlabel = parse_mux_ensemble(args.f[0])
-generator = Generator(days=args.days, output=args.output, packet_size=mux_packet_size, packet_address=mux_packet_address, datagroup_output=args.datagroup_output,ecc=ecc,eid=eid,label=label,shortlabel=shortlabel)
+generator = Generator(days=args.days, output=args.output, packet_size=mux_packet_size, packet_address=mux_packet_address, packet_bitrate=mux_packet_bitrate, datagroup_output=args.datagroup_output,ecc=ecc,eid=eid,label=label,shortlabel=shortlabel)
 resolved = resolve_epg(args.f[0], generator.generate_epg)

--- a/generate-epg
+++ b/generate-epg
@@ -45,11 +45,20 @@ def get_services_for_bearers(bearers, url, clientkey):
     logger.debug('getting services for bearers from %s : %s', url, bearers)
     req = urllib.request.Request(url)
     if clientkey:
+        logger.debug("Client ID passed to %s", url)
         req.add_header("Authorization", "ClientIdentifier " + clientkey)
-    response = urllib.request.urlopen(req)
-    logger.debug('SI successfully opened')
-    unmarshalled = xml.unmarshall(response.read().decode('utf-8'))
-    logger.debug('SI successfuly unmarshalled')
+    try:
+        response = urllib.request.urlopen(req)
+        logger.debug('SI successfully opened')
+        unmarshalled = xml.unmarshall(response.read().decode('utf-8'))
+        logger.debug('SI successfuly unmarshalled')
+    except urllib.error.HTTPError as err:
+        if err.code == 404:
+            logger.debug('could not find SI file at: %s', url)
+        elif err.code == 401 or err.code == 500:
+        	   logger.exception('authorization failure accessing SI file at: %s', url)
+        else:
+            logger.exception('error accessing SI file at: %s', pi_url)
 
     services = list(filter(lambda s : len(list(filter(lambda b : b in bearers, s.bearers))) > 0, unmarshalled.services))
     logger.debug('number of services found %d', len(services))
@@ -167,7 +176,6 @@ class Generator:
 
             # acquire an SI file, starting with the lower priority
             for server in servers:
-                print(server)
                 domain = server['target'][:-1]
                 if app == "radiospi":
                     url = 'https://%s/radiodns/spi/3.1/SI.xml' % domain 

--- a/generate-epg
+++ b/generate-epg
@@ -67,8 +67,11 @@ def get_services_for_bearers(bearers, url, clientkey):
         logger.debug('no services found for bearers %s from url %s',bearers, url)
     return services
 
-def get_filename():
-    return ''.join(random.choice(string.ascii_lowercase) for i in range(6))
+def get_shortobjectname(objectcount, suffix=''):
+    if objectcount < 26:
+        return ''.join([chr(objectcount+97)]) + suffix
+    else:
+        return ''.join([chr((objectcount // 26)+96), chr((objectcount % 26)+97)]) + suffix
 
 def encode_image(url):
     logger.debug('encoding image from %s', url)
@@ -165,7 +168,7 @@ class Generator:
     def generate_epg(self, responses):
 
         # lets provision a list of the files and encoders that we'll use to assemble the directory 
-        # list of tuples: (filename, params, function, args, kwargs)
+        # list of tuples: (objectname, params, function, args, kwargs)
         objects = []
 
         # our list of services
@@ -217,7 +220,6 @@ class Generator:
                     logger.debug('encoding service logo for: %s', service)
 
                     new_media = [] 
-                    logo_count = 1
                     for media in filter(lambda m: 
                         m.type in (Multimedia.LOGO_COLOUR_SQUARE, Multimedia.LOGO_COLOUR_RECTANGLE) or
                         (m.content in ('image/png') and (m.width, m.height) in ((32, 32), (112, 32), (128, 128), (320, 240))), 
@@ -234,20 +236,15 @@ class Generator:
    
                         # create a sensible contentname
                         logger.debug('Media content type is %s', media.content)
-                        name = "{service}_{count}_{width}_{height}.png".format(
-                            service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
-			                   count=logo_count,
-                            width=media.width,
-                            height=media.height)
-                        logo_count+=1
-                        logger.debug('creating MOT image %s from url: %s', name, media.url)
+                        objectname = get_shortobjectname(len(objects)+1)
+                        logger.debug('creating MOT image %s from url: %s', objectname, media.url)
                         
                         # create MOT Object
-                        o = MotObject(name, encode_image(media.url), ContentType.IMAGE_PNG)
+                        o = MotObject(objectname, encode_image(media.url), ContentType.IMAGE_PNG)
                         objects.append(o)
 
                         # set the name
-                        media.url = name
+                        media.url = objectname
 
                         # set the type
                         if (media.width, media.height) == (32, 32):
@@ -272,10 +269,10 @@ class Generator:
                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
                            try:
                                 day = now + timedelta(days=i)
-                                filename = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
-                                # Uncomment this next line if you want to use legacy filenames
-                                # filename = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
-                                logger.debug('making request for PI file to: %s to write out as: %s', pi_url, filename)
+                                objectname = get_shortobjectname(len(objects)+1)
+                                # Uncomment this next line if you want to use legacy objectnames
+                                # objectname = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
+                                logger.debug('making request for PI file to: %s to write out as: %s', pi_url, objectname)
                                 f = urllib.request.urlopen(pi_url)
                                 data = f.read().decode("utf-8")
                                 logger.debug('read %d bytes', len(data))
@@ -313,7 +310,7 @@ class Generator:
                                         schedule_info.scope.end = scope_end
                                         programme_info.schedules[0] = schedule_info
 
-                                        o = MotObject(filename, binary.marshall(programme_info).tobytes(), EpgContentType.PROGRAMME_INFORMATION)
+                                        o = MotObject(objectname, binary.marshall(programme_info).tobytes(), EpgContentType.PROGRAMME_INFORMATION)
                                         o.add_parameter(ScopeId(bearer.ecc, bearer.eid, sid=bearer.sid, scids=bearer.scids)) 
                                         o.add_parameter(ScopeStart(scope_start))
                                         o.add_parameter(ScopeEnd(scope_end))
@@ -330,12 +327,12 @@ class Generator:
 
                      
         # prepare the SI file
-        filename = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
-        # Uncomment this next line if you want to use legacy filenames
-        # filename = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
+        objectname = get_shortobjectname(0, '.EIB')
+        # Uncomment this next line if you want to use legacy objectnames
+        # objectname = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         service_info = ServiceInfo()
         service_info.originator = "OpenDigitalRadio SPI Generator"
-        logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), filename)
+        logger.debug('Preparing the Ensemble SI file with %d services to write out as %s', len(all_services), objectname)
         for service in all_services:
     
             # filter out non DAB/IP bearers
@@ -352,7 +349,7 @@ class Generator:
         # add the SI file 
         ensemble_label = MediumName(label)
         ensemble_shortlabel = ShortName(shortlabel)
-        o = MotObject(filename, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid, names=[ensemble_label,ensemble_shortlabel])).tobytes(), EpgContentType.SERVICE_INFORMATION)
+        o = MotObject(objectname, binary.marshall(service_info, ensemble=binary.Ensemble(ecc, eid, names=[ensemble_label,ensemble_shortlabel])).tobytes(), EpgContentType.SERVICE_INFORMATION)
         o.add_parameter(ScopeId(ecc, eid))
         objects.insert(0, o)
 

--- a/generate-epg
+++ b/generate-epg
@@ -73,7 +73,7 @@ def get_shortobjectname(objectcount, suffix=''):
     else:
         return ''.join([chr((objectcount // 26)+96), chr((objectcount % 26)+97)]) + suffix
 
-def encode_image(url):
+def encode_image(url, width, height):
     logger.debug('encoding image from %s', url)
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
     data = urllib.request.urlopen(req).read()
@@ -240,7 +240,7 @@ class Generator:
                         logger.debug('creating MOT image %s from url: %s', objectname, media.url)
                         
                         # create MOT Object
-                        o = MotObject(objectname, encode_image(media.url), ContentType.IMAGE_PNG)
+                        o = MotObject(objectname, encode_image(media.url, media.width, media.height), ContentType.IMAGE_PNG)
                         objects.append(o)
 
                         # set the name

--- a/generate-epg
+++ b/generate-epg
@@ -91,9 +91,15 @@ def encode_image(url, width, height):
     data = urllib.request.urlopen(req).read()
     logger.debug('read %d bytes of image data', len(data))
     image = Image.open(BytesIO(data))
+    dosave = False
+    if image.format != 'PNG':
+        logger.debug('WARN: image format is not PNG. Saving it as PNG.')
+        dosave = True
     if (image.width != width) or (image.height != height):
         logger.debug('WARN: image dimensions are incorrect (width:%d, height:%d)', image.width, image.height)
         image = image.resize(size=[width, height], resample=Image.BICUBIC)
+        dosave = True
+    if dosave:
         tf = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
         tempname = tf.name
         tf.close()

--- a/generate-epg
+++ b/generate-epg
@@ -13,6 +13,7 @@ lowest sizes. Also the specified number of days of PI files. All these are then 
 
 """
 
+import tempfile
 import argparse
 import os, sys
 from datetime import datetime, timedelta
@@ -78,11 +79,14 @@ def encode_image(url):
         logger.debug('WARN: image size is excessive (greater than 5kBytes)')
         image = Image.open(BytesIO(data))
         image = image.convert("P", palette=Image.ADAPTIVE)
-        compressed = image.save("/tmp/compressed.png", optimize=True)
-        temp = open('/tmp/compressed.png','rb')
+        tf = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
+        tempname = tf.name
+        tf.close()
+        compressed = image.save(tempname, optimize=True)
+        temp = open(tempname,'rb')
         data = temp.read()
         temp.close()
-        os.remove('/tmp/compressed.png')
+        os.remove(tempname)
         logger.debug('re-sized to %d bytes of image data', len(data))
     
     return data

--- a/generate-epg
+++ b/generate-epg
@@ -80,12 +80,6 @@ def get_services_for_bearers(bearers, url, clientkey):
         logger.debug('no services found for bearers %s from url %s',bearers, url)
     return services
 
-def get_shortobjectname(objectcount, suffix=''):
-    if objectcount < 26:
-        return ''.join([chr(objectcount+97)]) + suffix
-    else:
-        return ''.join([chr((objectcount // 26)+96), chr((objectcount % 26)+97)]) + suffix
-
 def encode_image(url, width, height):
     logger.debug('encoding image from %s', url)
     req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
@@ -256,7 +250,7 @@ class Generator:
    
                         # create a sensible contentname
                         logger.debug('Media content type is %s', media.content)
-                        objectname = get_shortobjectname(len(objects)+1)
+                        objectname = f'{len(objects):x}'
                         logger.debug('creating MOT image %s from url: %s', objectname, media.url)
                         
                         # create MOT Object
@@ -289,7 +283,7 @@ class Generator:
                            pi_url = 'http://%s/radiodns/spi/3.1/dab/%03x/%04x/%04x/%01x/%s' % (domain, ((bearer.sid >> 4 & 0xf00) + bearer.ecc), bearer.eid, bearer.sid, bearer.scids, day.strftime("%Y%m%d_PI.xml"))
                            try:
                                 day = now + timedelta(days=i)
-                                objectname = get_shortobjectname(len(objects)+1)
+                                objectname = '%s_%02x.%04x.%04x.%01x_PI.xml' % (day.strftime("%Y%m%d"), bearer.ecc, bearer.eid, bearer.sid, bearer.scids)
                                 # Uncomment this next line if you want to use legacy objectnames
                                 # objectname = 'w%sd%04xc0.EHA' % (day.strftime("%Y%m%d"), bearer.sid)
                                 logger.debug('making request for PI file to: %s to write out as: %s', pi_url, objectname)
@@ -348,7 +342,7 @@ class Generator:
                                    logger.exception('PI file at: %s is malformed', pi_url)
                      
         # prepare the SI file
-        objectname = get_shortobjectname(0, '.EIB')
+        objectname = '%s_%02x.%04x_SI.xml' % (now.strftime("%Y%m%d"),ecc,eid)
         # Uncomment this next line if you want to use legacy objectnames
         # objectname = 'e%02x%04xw%s.EIA' % (ecc, eid, now.strftime("%Y%m%d"))
         service_info = ServiceInfo()

--- a/generate-epg
+++ b/generate-epg
@@ -22,6 +22,7 @@ from json import dumps, JSONEncoder
 import random
 import string
 import re
+import csv
 from pprint import pprint
 
 from PIL import Image
@@ -40,9 +41,12 @@ def filter_by_bearer(service):
     bearers = [x for x in service.bearers if isinstance(x, (DabBearer))] # can include IP bearers if you like
     return service
 
-def get_services_for_bearers(bearers, url):
+def get_services_for_bearers(bearers, url, clientkey):
     logger.debug('getting services for bearers from %s : %s', url, bearers)
-    response = urllib.request.urlopen(url)
+    req = urlib.request(url)
+    if clientkey is not None:
+        req.add_header("Authorization", "ClientIdentifier " + clientkey)
+    response = req.urlopen(url)
     logger.debug('SI successfully opened')
     unmarshalled = xml.unmarshall(response.read().decode('utf-8'))
     logger.debug('SI successfuly unmarshalled')
@@ -82,6 +86,7 @@ parser.add_argument('-d', dest='days', type=int, default=2, help='number of days
 parser.add_argument('-p', dest='packet_size', type=int, default=96, help='Packet size in bytes')
 parser.add_argument('-a', dest='packet_address', type=int, default=1, help='Packet address')
 parser.add_argument('-D', dest='datagroup_output', action='store_true', help='output Datagroups instead of Packets')
+parser.add_argument('-c', dest='clientids', help='filename of CSV file of fqdn,ClientID key values')
 args = parser.parse_args()
 
 if args.debug:
@@ -93,6 +98,13 @@ logging.getLogger('spi.xml').setLevel(logging.DEBUG)
 # read in the mux config
 c = open(args.f[0]).read()
 
+# read in any fqdn / client IDs
+clientids = list()
+
+if args.clientids:
+    with open(args.clientids, newline='') as csvfile:
+        clientids = list(filter(None, csv.reader(csvfile)))
+        
 def calculate_scope(schedule): # this should probably be in the main codebase
     start = schedule.scope.start
     end = schedule.scope.end
@@ -142,6 +154,12 @@ class Generator:
             fqdn = response['fqdn']
             bearers = response['bearers']
             servers = response['servers']
+            clientkey = ""
+            
+            # is there a client id for this fqdn
+            for clientid in clientids:
+                if clientid[0] == fqdn:
+                    clientkey = clientid[1]
 
             # sort servers in priority (lowest), weighting highest
             servers = sorted(servers, key=lambda x: (-x['priority'], x['weight']))
@@ -152,7 +170,7 @@ class Generator:
                 url = 'http://%s/radiodns/spi/3.1/SI.xml' % domain 
                 logger.debug('getting SI document from %s', url)
                 try:
-                    services = get_services_for_bearers(bearers, url)
+                    services = get_services_for_bearers(bearers, url, clientkey)
                 except: continue # move onto the next SRV record
                 all_services.extend(services)
 
@@ -189,7 +207,7 @@ class Generator:
                         logger.debug('Media content type is %s', media.content)
                         name = "{service}_{count}_{width}_{height}.png".format(
                             service=service.get_name(ShortName.max_length).text.replace(" ", "_"),
-			    count=logo_count,
+			                   count=logo_count,
                             width=media.width,
                             height=media.height)
                         logo_count+=1


### PR DESCRIPTION
The filenames for the SI and PI files have been changed to match the formatting of the pre-specification format. This should not affect the operation on devices adhering the to the published standards.

The ScopeID of the PI files has been extended to add SId and SCIds values, which were previously omitted.